### PR TITLE
chore(grunt): adds grunt-conventional-changelog plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-saucelabs');
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   grunt.initConfig({
     clean: CLEAN_DIRS,
@@ -61,6 +62,11 @@ module.exports = function(grunt) {
         }
       }
     },
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
+      }
+    }
   });
 
   grunt.registerTask('test', ['build', 'connect', 'saucelabs-mocha']);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "wrench": "~1.5.1",
     "winston": "~0.7.2",
     "underscore.string": "2.3.3",
-    "q": "~0.9.7"
+    "q": "~0.9.7",
+    "grunt-conventional-changelog": "~1.0.0"
   },
   "goinstant": {
     "namespace": "integrations"


### PR DESCRIPTION
this commit adds the awesome grunt-conventional-changelog plugin which
makes it possible to autogenerate changelogs based on the given
commit history

all you have to do is to follow some conventions

the plugin is used by angular.js itself and plenty other projects

For more info see: http://github.com/btford/grunt-conventional-changelog
