### PR TITLE
feat($goConnection): Enable deferred conn initialization 

### DIFF
--- a/docs/v1/connection.md
+++ b/docs/v1/connection.md
@@ -88,11 +88,11 @@ configuration stage, in these situations you'll use `$connect`.
 
 `$connect` accepts two parameters a `connectUrl` and an `optionsObject`.  The object has two optional
 properties: `user` which can be a [JWT](../../guides/users_and_authentication.md)
-or a set of default user properties and `room`, which is the name of the room you wish
+or a set of default user properties and [room](../../javascript_api/rooms/index.md), which is the name of the room you wish
 to use.  By default you join the 'Lobby'.
 
-A connection once established can still be shared among controllers using the `$ready()`
-method, which returns a promise.
+The `$ready` method cannot ***currently*** be called until after the `$connect`
+method has been invoked.
 
 **Note: You should not use this method in conjunction with
 `goConnectionProvider.$set`**

--- a/docs/v1/connection.md
+++ b/docs/v1/connection.md
@@ -7,8 +7,9 @@ connection!
 ## Contents
 
 1. [Code Example](#code-example)
-2. [$goConnection#$set](#$goconnection#$set)
-3. [$goConnection#$ready](#$goconnection#$ready)
+2. [$goConnection#$connect](#goConnection#$connect)
+3. [$goConnection#$set](#$goconnection#$set)
+4. [$goConnection#$ready](#$goconnection#$ready)
 
 ## Code Example
 
@@ -76,6 +77,70 @@ JavaScript libraries.
     <div ng-controller="completeControl"></div>
   </body>
 </html>
+```
+
+## $goConnection#$connect
+
+### Description
+
+In some cases, you will need to defer connecting to GoInstant until after Angular's
+configuration stage, in these situations you'll use `$connect`.
+
+`$connect` accepts two parameters a `connectUrl` and an `optionsObject`.  The object has two optional
+properties: `user` which can be a [JWT](../../guides/users_and_authentication.md)
+or a set of default user properties and `room`, which is the name of the room you wish
+to use.  By default you join the 'Lobby'.
+
+A connection once established can still be shared among controllers using the `$ready()`
+method, which returns a promise.
+
+**Note: You should not use this method in conjunction with
+`goConnectionProvider.$set`**
+
+### Methods
+
+- ##### **$goConnection.$connect(connectUrl)**
+- ##### **$goConnection.$connect(connectUrl, optionsObject)**
+
+### Parameters
+
+| connectUrl |
+|:---|
+| Type: [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) |
+| Your registered application URL (e.g. https://goinstant.net/YOURACCOUNT/YOURAPP). |
+
+| optionsObject |
+|:---|
+| Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) |
+| An object with three properties: `user`, `room` and `rooms`. |
+| - `user` is an optional [JWT](../../guides/users_and_authentication.md) or Object. If not provided, the user will connect as a guest. If provided and an Object, the user will connect as a guest with the given default user properties. |
+| - `room` is an optional string. If provided, the [Room](../../javascript_api/rooms/index.md) with the provided name will be joined, otherwise the 'lobby' Room will be joined. |
+
+### Returns
+
+| promiseObject |
+|:---|
+| Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) |
+| A Q powered promise which is resolved once a connection to GoInstant has been established or is rejected if an error is encountered.  |
+
+### Example
+
+```js
+// Specify GoAngular as a dependency and configure your connection
+angular.module('yourApp', ['goangular'])
+  .controller('completeControl', function($goConnection) {
+    $goConnection.$connect('https://goinstant.net/YOURACCOUNT/YOURAPP', {
+      user: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczo...'
+      room: 'myCustomRoom'
+    }).then(
+      function(connection) {
+        // Connected
+      },
+      function(err) {
+        // Error encountered
+      }
+    );
+  });
 ```
 
 ## $goConnection#$set

--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -156,7 +156,7 @@ Let's see it all tied together:
 <head>
   <title>GoAngular Chat Tutorial</title>
 </head>
-<body>
+<body ng-controller="ChatCtrl">
   <h1>Getting Started with GoAngular Chat</h1>
 
   <!-- Messages displayed -->

--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -6,11 +6,11 @@ You can find the source files for this demo (with some slight enhancements) [her
 
 ##  Contents
 
-#### [Sign Up for a GoInstant Account](#sign-up-for-a-goinstant-account)
-#### [Install GoAngular](#install-goangular)
-#### [Create and Synchronize a Collection of Chat Messages](#create-&-synchronize-a-collection-of-chat-messages)
-#### [Add a New Message to Our Collection](#add-a-new-message-to-our-collection)
-#### [The Kitchen Sink Demo](#the-kitchen-sink-demo)
+1. [Sign Up for a GoInstant Account](#sign-up-for-a-goinstant-account)
+2. [Install GoAngular](#install-goangular)
+3. [Create and Synchronize a Collection of Chat Messages](#create-&-synchronize-a-collection-of-chat-messages)
+4. [Add a New Message to Our Collection](#add-a-new-message-to-our-collection)
+5. [The Kitchen Sink Demo](#the-kitchen-sink-demo)
 
 ## Sign Up for a GoInstant Account
 
@@ -53,7 +53,7 @@ We'll use the `$goConnection` provider during Angular's configuration stage to s
 ```js
 var chatApp = angular.module('Chat', ['goangular']);
 
-chatApp.configure(function($goConnectionProvider) {
+chatApp.config(function($goConnectionProvider) {
   $goConnectionProvider.$set('https://goinstant.net/ACCOUNT_NAME/APP_NAME');
 });
 ```
@@ -63,7 +63,7 @@ Now that our connection is configured we can inject the `$goKey` service into a 
 ```js
 var chatApp = angular.module('Chat', ['goangular']);
 
-chatApp.configure(function($goConnectionProvider) {
+chatApp.config(function($goConnectionProvider) {
   $goConnectionProvider.$set('https://goinstant.net/ACCOUNT_NAME/APP_NAME');
 });
 
@@ -182,7 +182,7 @@ Let's see it all tied together:
   <script>
     var chatApp = angular.module('Chat', ['goangular']);
 
-    chatApp.configure(function($goConnectionProvider) {
+    chatApp.config(function($goConnectionProvider) {
       $goConnectionProvider.$set('https://goinstant.net/ACCOUNT_NAME/APP_NAME');
     });
 

--- a/docs/v1/getting_started.md
+++ b/docs/v1/getting_started.md
@@ -146,7 +146,7 @@ chatApp.controller('ChatCtrl', function($scope, $goKey) {
 
 Each time an item is added, our model is updated, and so is (of course) our view!
 
-## The Kitchen Sink
+## The Kitchen Sink Demo
 
 Let's see it all tied together:
 

--- a/docs/v1/static/html/goangular_frontpage.html
+++ b/docs/v1/static/html/goangular_frontpage.html
@@ -226,17 +226,17 @@
     <div class="col">
       <img src="static/images/icon-rapid.png" alt="Rapid Development">
       <h3>Optimized for rapid development</h3>
-      <p>Every model that can be synchronized in your controller's scope will be. <a href="concepts.html#controller">SEE MORE &raquo;</a></p>
+      <p>Quickly add data-synchronization and collaboration features to your Angular app</p>
     </div>
     <div class="col">
       <img src="static/images/icon-control.png" alt="Complete Control">
       <h3>Complete control when it matters</h3>
-      <p>Choose exactly which models are included or excluded using either ole fashioned strings or regular expressions. <a href="concepts.html#scope-filter">SEE MORE &raquo;</a></p>
+      <p>Simply synchronize an entire data model, or customize how synchronization is managed.</p>
     </div>
     <div class="col">
       <img src="static/images/icon-sync.png" alt="Synchronize Forever">
-      <h3>Configure once, synchronize forever</h3>
-      <p>Tell GoAngular what to synchronize and regardless of when you add models to your controller, they'll be synchronized. <a href="concepts.html#scope-digest">SEE MORE &raquo;</a></p>
+      <h3>Open source &amp; fully tested</h3>
+      <p>TAn open-source, community driven integration backed by proper tests.</p>
     </div>
   </div>
 </div>

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -40,7 +40,19 @@ function Connection() {
   });
 }
 
+/**
+ * Configure & connect to GoInstant
+ * @param {String} url - Registered application URL
+ * @param {Object} [opts]
+ * @config {Mixed} user - is an optional JWT or user object, defaults to 'guest'
+ * @config {String} room - is an optional room name, defaults to 'lobby'
+ * with the room option
+ */
 Connection.prototype.$connect = function(url, opts) {
+  if (this.$$connection) {
+    return this.$$connection;
+  }
+
   this.$set(url, opts);
   this.$$connect();
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -49,6 +49,12 @@ function Connection() {
  * with the room option
  */
 Connection.prototype.$connect = function(url, opts) {
+  if (this.$$configured) {
+    throw new Error(
+      '$connect should not be used in conjunction with $set or invoked twice'
+    );
+  }
+
   if (this.$$connection) {
     return this.$$connection;
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -25,20 +25,27 @@ module.exports = Connection;
  *      goConnectionProvider.set('https://goinstant.net/YOURACCOUNT/YOURAPP');
  *    })
  *    .controller('YourCtrl', function(goConnection) {
- *      goConnection.ready().then(function(connection) {
+ *      goConnection.$ready().then(function(connection) {
  *        // connected
  *      });
  *    });
  */
 function Connection() {
   _.extend(this, {
-    _opts: {},
-    _connection: null,
-    _connecting: false,
-    _configured: false,
-    _rooms: {}
+    $$opts: {},
+    $$connection: null,
+    $$connecting: false,
+    $$configured: false,
+    $$rooms: {}
   });
 }
+
+Connection.prototype.$connect = function(url, opts) {
+  this.$set(url, opts);
+  this.$$connect();
+
+  return this.$$connection;
+};
 
 /**
  * Configure a future goinstant connection
@@ -53,10 +60,10 @@ Connection.prototype.$set = function(url, opts) {
     throw new Error('GoAngular requires the GoInstant library.');
   }
 
-  this._configured = true;
-  this._conn = new goinstant.Connection(url);
+  this.$$configured = true;
+  this.$$conn = new goinstant.Connection(url);
 
-  _.extend(this, { _opts: (opts || {}), _url: url, _configured: true });
+  _.extend(this, { $$opts: (opts || {}), $$url: url, $$configured: true });
 };
 
 /**
@@ -68,49 +75,63 @@ Connection.prototype.$get = function() {
     throw new Error('GoAngular requires the GoInstant library.');
   }
 
-  if (!this._connecting) {
-    this._connect();
+  if (this.$$configured && !this.$$connecting) {
+    this.$$connect();
   }
 
   return this;
 };
 
 Connection.prototype.$key = function(keyName, roomName) {
-  roomName = roomName || this._opts.room || 'lobby';
+  if (!this.$$configured) {
+    throw new Error(
+      'You must configure you connection first. ' +
+      'Find additional details: ' +
+      'https://developers.goinstant.com/v1/GoAngular/connection.html');
+  }
 
-  if (!this._rooms[roomName]) {
+  roomName = roomName || this.$$opts.room || 'lobby';
+
+  if (!this.$$rooms[roomName]) {
     var self = this;
 
-    this._rooms[roomName] = true;
-    this._connection = this._connection.then(function() {
-      return self._conn.room(roomName).join().then(function() {
-        return self._conn;
+    this.$$rooms[roomName] = true;
+    this.$$connection = this.$$connection.then(function() {
+      return self.$$conn.room(roomName).join().then(function() {
+        return self.$$conn;
       });
     });
   }
 
-  return this._conn.room(roomName).key(keyName);
+  return this.$$conn.room(roomName).key(keyName);
 };
 
 /**
  * Responsible for connecting to goinstant, assigns a promise to the private
  * connection property
  */
-Connection.prototype._connect = function() {
-  if (!this._configured) {
+Connection.prototype.$$connect = function() {
+  if (!this.$$configured) {
     throw new Error('The GoInstant connection must be configured first.');
   }
 
-  var opts = _.pick(this._opts, 'user');
+  var user  = this.$$opts.user || {};
 
-  this._connecting = true;
-  this._connection = this._conn.connect(opts, function() {});
+  this.$$connecting = true;
+  this.$$connection = this.$$conn.connect(user || {}, function() {});
 };
 
 /**
  * @returns {Object} connection - a promise which will be resolved once a
  * connection has been established or rejected if an async error is encountered
  */
-Connection.prototype.ready = function() {
-  return this._connection;
+Connection.prototype.$ready = function() {
+  if (!this.$$configured) {
+    throw new Error(
+      'You must configure you connection first.' +
+      'Find additional details:' +
+      ' https://developers.goinstant.com/v1/GoAngular/connection.html');
+  }
+
+  return this.$$connection;
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -53,7 +53,7 @@ function Model($goSync, $goConnection, key, room) {
 Model.prototype.$sync = function() {
   var self = this;
 
-  var connected = self.$$goConnection.ready();
+  var connected = self.$$goConnection.$ready();
 
   connected.then(function() {
     self.$$sync = self.$$goSync(self.$$key, self);
@@ -88,7 +88,7 @@ Model.prototype.$set = function(value, opts) {
   opts = opts || {};
 
   var self = this;
-  return this.$$goConnection.ready().then(function() {
+  return this.$$goConnection.$ready().then(function() {
     return self.$$key.set(value, opts);
   });
 };
@@ -103,7 +103,7 @@ Model.prototype.$add = function(value, opts) {
   opts = opts || {};
 
   var self = this;
-  return this.$$goConnection.ready().then(function() {
+  return this.$$goConnection.$ready().then(function() {
     return self.$$key.add(value, opts);
   });
 };
@@ -117,7 +117,7 @@ Model.prototype.$remove = function(opts) {
   opts = opts || {};
 
   var self = this;
-  return this.$$goConnection.ready().then(function() {
+  return this.$$goConnection.$ready().then(function() {
     return self.$$key.remove(opts);
   });
 };

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -64,16 +64,16 @@ describe('GoAngular.goConnection', function() {
 
         goConnection.$set(url, opts);
 
-        assert.equal(goConnection._opts, opts);
-        assert.equal(goConnection._url, url);
-        assert(goConnection._configured);
+        assert.equal(goConnection.$$opts, opts);
+        assert.equal(goConnection.$$url, url);
+        assert(goConnection.$$configured);
       });
 
       it('connects to goinstant', function() {
         goConnection.$set(url, opts);
         goConnection.$get();
 
-        sinon.assert.calledWith(connect, opts);
+        sinon.assert.calledWith(connect, opts.user);
       });
 
       describe('error cases', function() {
@@ -88,8 +88,8 @@ describe('GoAngular.goConnection', function() {
 
         it('throws if the connection has not been configured', function() {
           assert.exception(function() {
-            goConnection.$get();
-          }, 'The GoInstant connection must be configured first.');
+            goConnection.$ready();
+          }, /You must configure you connection first/);
         });
       });
     });

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -66,7 +66,7 @@ describe('GoAngular.goConnection', function() {
 
         assert.equal(goConnection.$$opts, opts);
         assert.equal(goConnection.$$url, url);
-        assert(goConnection.$$configured);
+        assert.equal(goConnection.$$configured, true);
       });
 
       it('connects to goinstant', function() {

--- a/tests/model.js
+++ b/tests/model.js
@@ -32,7 +32,7 @@ describe('GoAngular.goKey', function() {
 
     initialize = sandbox.stub();
 
-    $goConnection = { ready: sinon.stub().returns(fakePromise) };
+    $goConnection = { $ready: sinon.stub().returns(fakePromise) };
     $goSync = sandbox.stub().returns({
       $initialize: initialize
     });


### PR DESCRIPTION
@MaheshCasiraghi identified an issue whereby authentication could
only be performed during the Angular configuration stage.  The addition
of the `$connect` method now allows developers too configure, and connect
at any point in the life-cycle of their application.

Example:

``` js
ourCoolApp.controller('sweetController', function($scope, $goKey, $goConnection) {
  var url = "https://goinstant.net/ACCOUNT_NAME/APP_NAME";
  var opts = { user: 'eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ...' };

  $goConnection.$connect(url, opts).then(function(c) {
    return c.room('lobby').join();
  }).then(function(result) {
    console.log(result.user);
  });

  $scope.todos = $goKey('todos');
  $scope.todos.$sync();
});
```
