### PR TITLE
chore(model.js): #on/#off listener passed outside of opts obj

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -137,22 +137,24 @@ Model.prototype.$omit = function() {
  * Bind a listener to events on this key
  * @public
  */
-Model.prototype.$on = function(eventName, listener) {
+Model.prototype.$on = function(eventName, opts, listener) {
   if (!_.contains(LOCAL_EVENTS, eventName)) {
-    return this.$$key.on(eventName, listener);
+    return this.$$key.on(eventName, opts, listener);
   }
 
-  this.$$emitter.on(eventName, listener);
+  // Overloaded method, opts = listener
+  this.$$emitter.on(eventName, opts);
 };
 
 /**
  * Remove a listener on this key
  * @public
  */
-Model.prototype.$off = function(eventName, listener) {
+Model.prototype.$off = function(eventName, opts, listener) {
   if (!_.contains(LOCAL_EVENTS, eventName)) {
-    return this.$$key.off(eventName, listener);
+    return this.$$key.off(eventName, opts, listener);
   }
 
-  this.$$emitter.off(eventName, listener);
+  // Overloaded method, opts = listener
+  this.$$emitter.off(eventName, opts);
 };

--- a/tests/model.js
+++ b/tests/model.js
@@ -102,18 +102,46 @@ describe('GoAngular.goKey', function() {
     describe('$on', function() {
 
       it('add an event listener', function() {
-        model.$on('eventName', 'listener');
+        var fakeLstner = sinon.stub();
 
-        sinon.assert.calledWith(fakeKey.on, 'eventName', 'listener');
+        model.$on('eventName', fakeLstner);
+
+        sinon.assert.calledWith(fakeKey.on, 'eventName', fakeLstner);
+      });
+
+      it('add an event listener with options object', function() {
+        var fakeOpts = {
+          local: true
+        };
+
+        var fakeLstner = sinon.stub();
+
+        model.$on('eventName', fakeOpts, fakeLstner);
+
+        sinon.assert.calledWith(fakeKey.on, 'eventName', fakeOpts, fakeLstner);
       });
     });
 
     describe('$off', function() {
 
-      it('add an event listener', function() {
-        model.$off('eventName', 'listener');
+      it('remove an event listener', function() {
+        var fakeLstner = sinon.stub();
 
-        sinon.assert.calledWith(fakeKey.off, 'eventName', 'listener');
+        model.$off('eventName', fakeLstner);
+
+        sinon.assert.calledWith(fakeKey.off, 'eventName', fakeLstner);
+      });
+
+      it('remove an event listener with options object', function() {
+        var fakeOpts = {
+          bubble: true
+        };
+
+        var fakeLstner = sinon.stub();
+
+        model.$off('eventName', fakeOpts, fakeLstner);
+
+        sinon.assert.calledWith(fakeKey.off, 'eventName', fakeOpts, fakeLstner);
       });
     });
 


### PR DESCRIPTION
Passing a listener to key#on/#off through the options object is being deprecated in GoInstant. This change will accept a listener as a third parameter to model#$on/$off.
