### PR TITLE
Use `master` branch for Travis build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/goinstant/goangular.png)](https://travis-ci.org/goinstant/goangular)
+[![Build Status](https://travis-ci.org/goinstant/goangular.png?branch=master)](https://travis-ci.org/goinstant/goangular?branch=master)
 
 [![GoAngular](https://developers.goinstant.com/v1/GoAngular/static/images/goangular_logo.png)](https://www.goangular.org)
 


### PR DESCRIPTION
Fixes a small issue where test/develop branches will cause the build status to display as failing in your main README
